### PR TITLE
Upgraded to work with Entities 1.0.0-pre.15

### DIFF
--- a/Assets/UnitTests/ECSTestsFixture/ECSTestsFixture.cs
+++ b/Assets/UnitTests/ECSTestsFixture/ECSTestsFixture.cs
@@ -120,7 +120,7 @@ public abstract class ECSTestsFixture : ECSTestsCommonBase
 			// Clean up systems before calling CheckInternalConsistency because we might have filters etc
 			// holding on SharedComponentData making checks fail
 			while (m_World.Systems.Count > 0)
-				m_World.DestroySystem(m_World.Systems[0]);
+				m_World.DestroySystem(m_World.Systems[0].SystemHandle);
 
 			m_ManagerDebug.CheckInternalConsistency();
 


### PR DESCRIPTION
Made DestroySystem take SystemHandle instead of the Managed system object.